### PR TITLE
ACG: API to retrieve registered service handle and appid

### DIFF
--- a/include/public/webos_application.h
+++ b/include/public/webos_application.h
@@ -37,9 +37,33 @@ struct webos_application_event_handlers {
 	void (*lowmemory)(enum webos_applocation_low_memory_state state, void *user_data);
 };
 
-bool webos_application_init(const char *app_id, struct webos_application_event_handlers *event_handlers, void *user_data);
+/*
+ *  Register an application on LS2 bus and declare it to the Application Manager
+ *  @param app_id          the appId to give to the Application Manager
+ *  @param service_name    the name of the service on the LS2 bus (if NULL, app_id is used). Can be a different name if application is run from a container
+ *  @param event_handlers  set of facultative callback pointers that will be called when the corresponding event occurs
+ *  @param user_data       user data to pass to the event handlers
+ */
+bool webos_application_init(const char *app_id, const char *service_name, struct webos_application_event_handlers *event_handlers, void *user_data);
+
+/*
+ *  Attach the application to a GLib event loop
+ */
 bool webos_application_attach(GMainLoop *mainloop);
+
+/*
+ *  Unregister app and free resources
+ */
 void webos_application_cleanup(void);
+
+/*
+ * Retrieve current registered application service handle
+ * @param app_id[out]          appId known by the Application Manager
+ * @param service_handle[out]  main service handle of the application
+ * @return true is success
+           false is no handle is registered yet.
+ */
+bool webos_application_get_handle(char **app_id, struct LSHandle **service_handle);
 
 #ifdef __cplusplus
 }

--- a/src/webos_application.c
+++ b/src/webos_application.c
@@ -32,6 +32,23 @@ struct webos_application_config {
 
 struct webos_application_config *app_config = NULL;
 
+bool webos_application_get_handle(char **app_id, LSHandle **service_handle)
+{
+	if(!app_id || !service_handle) return false;
+	
+	*app_id = NULL;
+	*service_handle = NULL;
+
+	if(app_config) {
+		*app_id = g_strdup(app_config->app_id);
+		*service_handle = app_config->service_handle;
+
+		return true;
+	}
+
+	return false;
+}
+
 static bool register_cb(LSHandle *handle, LSMessage *message, void *user_data)
 {
 	const char *payload;
@@ -130,7 +147,7 @@ cleanup:
 	return true;
 }
 
-bool webos_application_init(const char *app_id, struct webos_application_event_handlers *event_handlers, void *user_data)
+bool webos_application_init(const char *app_id, const char *service_name, struct webos_application_event_handlers *event_handlers, void *user_data)
 {
 	LSHandle *service_handle;
 	LSError lserror;
@@ -142,9 +159,12 @@ bool webos_application_init(const char *app_id, struct webos_application_event_h
 	if (app_id == NULL || strlen(app_id) == 0)
 		return false;
 
+	if (service_name == NULL)
+		service_name = app_id;
+
 	LSErrorInit(&lserror);
 
-	if (!LSRegister(NULL, &service_handle, &lserror)) {
+	if (!LSRegister(service_name, &service_handle, &lserror)) {
 		g_warning("Failed to register LS2 service object: %s", lserror.message);
 		LSErrorFree(&lserror);
 		return false;


### PR DESCRIPTION
With ACG the same registered service handle has to be used for the whole
application, so retrieving it is necessary.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>