### PR TITLE
Remove the workaround to include lunaservice.h

### DIFF
--- a/src/webos_application.c
+++ b/src/webos_application.c
@@ -16,7 +16,7 @@
 
 #include <string.h>
 #include <glib.h>
-#include <lunaservice.h>
+#include <luna-service2/lunaservice.h>
 #include <pbnjson.h>
 
 #include "webos_application.h"


### PR DESCRIPTION
Use `luna-service2/lunaservice.h` instead.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>